### PR TITLE
Add support of express server bfx-report-express as submodule of bfx-report-ui repo

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2019 iFinex Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/init.sh
+++ b/init.sh
@@ -36,6 +36,7 @@ if [ $isDevEnv != 0 ]; then
 fi
 
 frontendFolder="$PWD/bfx-report-ui"
+expressFolder="$frontendFolder/bfx-report-express"
 backendFolder="$PWD/bfx-report"
 
 rm -f ./package-lock.json
@@ -54,6 +55,10 @@ git pull --recurse-submodules
 git submodule update --remote
 
 cd $frontendFolder
+git submodule sync
+git submodule update --init --recursive
+git pull --recurse-submodules
+git submodule update --remote
 npm i
 
 sed -i -e "s/API_URL: .*,/API_URL: \'http:\/\/localhost:34343\/api\',/g" $frontendFolder/src/var/config.js
@@ -64,13 +69,16 @@ if [ $isDevEnv != 0 ]; then
 fi
 
 sed -i -e "s/showSyncMode: .*,/showSyncMode: true,/g" $frontendFolder/src/var/config.js
+cp $expressFolder/config/default.json.example $expressFolder/config/default.json
 npm run build
+
+cd $expressFolder
+npm i --production --target=2.0.11 --runtime=electron --arch=x64 --dist-url=https://atom.io/download/electron
 
 cd $backendFolder
 npm i --production --target=2.0.11 --runtime=electron --arch=x64 --dist-url=https://atom.io/download/electron
 
 cp config/schedule.json.example config/schedule.json
-cp config/default.json.example config/default.json
 cp config/common.json.example config/common.json
 cp config/service.report.json.example config/service.report.json
 cp config/facs/grc.config.json.example config/facs/grc.config.json

--- a/package.json
+++ b/package.json
@@ -62,11 +62,13 @@
       "build/icons",
       "bfx-report",
       "!bfx-report/README.md",
-      "!bfx-report/pm2.config.js",
       "!bfx-report/.mocha.opts",
       "!bfx-report/test",
       "!bfx-report-ui",
       "bfx-report-ui/build",
+      "bfx-report-ui/bfx-report-express",
+      "!bfx-report-ui/bfx-report-express/README.md",
+      "!bfx-report-ui/bfx-report-express/pm2.config.js",
       {
         "from": "bfx-report/node_modules",
         "to": "bfx-report/node_modules",
@@ -83,6 +85,19 @@
       {
         "from": "bfx-report/node_modules/bfx-api-node-rest/node_modules",
         "to": "bfx-report/node_modules/bfx-api-node-rest/node_modules",
+        "filter": [
+          "**/*",
+          "!.bin",
+          "!**/node_modules/.bin",
+          "!**/*.md",
+          "!**/LICENSE",
+          "!**/CHANGELOG",
+          "!**/test"
+        ]
+      },
+      {
+        "from": "bfx-report-ui/bfx-report-express/node_modules",
+        "to": "bfx-report-ui/bfx-report-express/node_modules",
         "filter": [
           "**/*",
           "!.bin",

--- a/server.js
+++ b/server.js
@@ -6,6 +6,8 @@ const { writeFileSync } = require('fs')
 const EventEmitter = require('events')
 
 const root = path.join(__dirname, 'bfx-report')
+const expressRoot = path.join(__dirname, 'bfx-report-ui/bfx-report-express')
+const pathToExpressConfDir = path.join(expressRoot, 'config')
 const pathToConfDir = path.join(root, 'config')
 const pathToConfFacs = path.join(pathToConfDir, 'facs')
 const pathToConfFacsGrc = path.join(pathToConfFacs, 'grc.config.json')
@@ -13,7 +15,7 @@ const confFacsGrc = require(pathToConfFacsGrc)
 
 if (!process.env.NODE_ENV) process.env.NODE_ENV = 'production'
 process.send = process.send || (() => {})
-process.env.NODE_CONFIG_DIR = pathToConfDir
+process.env.NODE_CONFIG_DIR = pathToExpressConfDir
 process.versions.electron = process.env.ELECTRON_VERSION
 
 const env = {
@@ -103,7 +105,7 @@ process.on('SIGTERM', () => ipc && ipc.kill())
 
 emitter.once('ready:grapes-worker', () => {
   try {
-    const { app } = require(path.join(root, 'app.js'))
+    const { app } = require(expressRoot)
 
     app.once('listened', server => {
       emitter.emit('ready:server', server)


### PR DESCRIPTION
This PR adds support of the express server [bfx-report-express](https://github.com/bitfinexcom/bfx-report-express/pull/1) as the  submodule of [bfx-report-ui](https://github.com/bitfinexcom/bfx-report-ui) repository
 ### Dependencies:
- This PR depends on those PRs:
https://github.com/bitfinexcom/bfx-report-express/pull/1
https://github.com/bitfinexcom/bfx-report/pull/93
https://github.com/bitfinexcom/bfx-report-ui/pull/210