### PR TITLE
Fix launching on mac by double click issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,6 @@
 Already complied binaries can be found on release section [release section](https://github.com/bitfinexcom/bfx-report-electron/releases). </br>
 Download the correspondent binary according your operating system.</br>  
 
-#### <font color="red">macOS Mojave known issue</font></br>
-On macOS Mojave software is not running on double click.</br>
-As to run it from macOs open a console from folder where software was exported to and run:
-
-```
-./bfx-report-electron
-```
-We are actually working on a solution for this.
-
 ## Setup
 
 ### Install
@@ -44,6 +35,7 @@ For doing builds for other platforms please have “Multi Platform Build” in c
 For creating the distributions please run the following commands, after the execution is finished the file would be in */dist* folder
 
 - Individual:
+
 ```console
 #Distribution for Linux
 npm run dist-linux
@@ -56,6 +48,11 @@ npm run dist-mac
 ```
 
 - Linux + Windows + MacOs:
+
 ```console
 npm start
 ```
+
+## Export CSV reports
+
+Exported CSV reports are contained in the root folder of the application in `csv` directory for Linux and Windows releases, and in `~/Library/Application Support/bfx-report-electron/csv` directory for Mac release

--- a/init.sh
+++ b/init.sh
@@ -90,10 +90,6 @@ if [ $isDevEnv != 0 ]; then
   sed -i -e "s/\"restUrl\": .*,/\"restUrl\": \"https:\/\/test.bitfinex.com\",/g" $backendFolder/config/service.report.json
 fi
 
-touch db/lokue_queue_1_aggregator.db.json
-touch db/lokue_queue_1_processor.db.json
-touch db/db-sqlite_sync_m0.db
-
 cd $ROOT
 
 if [ $isNotSkippedReiDeps != 0 ]; then

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-report-electron",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Reporting tool",
   "author": "bitfinex.com",
   "main": "index.js",

--- a/server.js
+++ b/server.js
@@ -2,7 +2,6 @@
 
 const { fork } = require('child_process')
 const path = require('path')
-const { writeFileSync } = require('fs')
 const EventEmitter = require('events')
 
 const root = path.join(__dirname, 'bfx-reports-framework')
@@ -29,7 +28,6 @@ const {
   killGrapes,
   getDefaultPorts,
   getFreePort,
-  checkAndChangeAccess,
   serializeError
 } = require('./src/helpers')
 
@@ -61,10 +59,6 @@ let isMigrationsError = false
       return
     }
 
-    checkAndChangeAccess(pathToConfFacs)
-    checkAndChangeAccess(pathToConfFacsGrc)
-    writeFileSync(pathToConfFacsGrc, JSON.stringify(confFacsGrc))
-
     process.env.NODE_CONFIG = JSON.stringify({
       app: {
         port: ports.expressApiPort
@@ -90,7 +84,8 @@ let isMigrationsError = false
       `--csvFolder=${pathToUserData}/csv`,
       `--tempFolder=${pathToUserData}/temp`,
       `--logsFolder=${pathToUserData}/logs`,
-      `--dbFolder=${pathToUserData}`
+      `--dbFolder=${pathToUserData}`,
+      `--grape=${grape}`
     ], {
       env,
       cwd: process.cwd(),

--- a/server.js
+++ b/server.js
@@ -4,6 +4,7 @@ const { fork } = require('child_process')
 const path = require('path')
 const { writeFileSync } = require('fs')
 const EventEmitter = require('events')
+const electron = require('electron')
 
 const root = path.join(__dirname, 'bfx-reports-framework')
 const expressRoot = path.join(__dirname, 'bfx-report-ui/bfx-report-express')
@@ -43,6 +44,8 @@ let isMigrationsError = false
 
 ;(async () => {
   try {
+    const app = electron.app || electron.remote.app
+    const pathToUserData = app.getPath('userData')
     const defaultPorts = getDefaultPorts()
     const ports = await getFreePort(defaultPorts)
     const grape = `http://127.0.0.1:${ports.grape2ApiPort}`
@@ -82,10 +85,13 @@ let isMigrationsError = false
       `--apiPort=${ports.workerApiPort}`,
       `--wsPort=${ports.workerWsPort}`,
       '--dbId=1',
-      '--csvFolder=../../../csv',
       '--isSchedulerEnabled=true',
       '--isElectronjsEnv=true',
-      `--isLoggerDisabled=${isNotDevEnv}`
+      `--isLoggerDisabled=${isNotDevEnv}`,
+      `--csvFolder=${pathToUserData}/csv`,
+      `--tempFolder=${pathToUserData}/temp`,
+      `--logsFolder=${pathToUserData}/logs`,
+      `--dbFolder=${pathToUserData}`
     ], {
       env,
       cwd: process.cwd(),

--- a/server.js
+++ b/server.js
@@ -30,7 +30,8 @@ const {
   killGrapes,
   getDefaultPorts,
   getFreePort,
-  checkAndChangeAccess
+  checkAndChangeAccess,
+  serializeError
 } = require('./src/helpers')
 
 const {
@@ -56,7 +57,7 @@ let isMigrationsError = false
     if (defaultPorts.expressApiPort !== ports.expressApiPort) {
       process.send({
         state: 'error:express-port-required',
-        err: new RunningExpressOnPortError()
+        err: serializeError(new RunningExpressOnPortError())
       })
 
       return
@@ -158,7 +159,10 @@ let isMigrationsError = false
     process.on('SIGHUP', () => ipc && ipc.kill())
     process.on('SIGTERM', () => ipc && ipc.kill())
   } catch (err) {
-    process.send({ state: 'error:app-init', err })
+    process.send({
+      state: 'error:app-init',
+      err: serializeError(err)
+    })
   }
 })()
 
@@ -170,7 +174,10 @@ emitter.once('ready:grapes-worker', () => {
       emitter.emit('ready:server', server)
     })
   } catch (err) {
-    process.send({ state: 'error:app-init', err })
+    process.send({
+      state: 'error:app-init',
+      err: serializeError(err)
+    })
   }
 })
 

--- a/server.js
+++ b/server.js
@@ -43,6 +43,9 @@ let isMigrationsError = false
 ;(async () => {
   try {
     const pathToUserData = process.env.PATH_TO_USER_DATA
+    const pathToCsvFolder = process.platform === 'darwin'
+      ? pathToUserData
+      : '../../..'
     const defaultPorts = getDefaultPorts()
     const ports = await getFreePort(defaultPorts)
     const grape = `http://127.0.0.1:${ports.grape2ApiPort}`
@@ -81,7 +84,7 @@ let isMigrationsError = false
       '--isSchedulerEnabled=true',
       '--isElectronjsEnv=true',
       `--isLoggerDisabled=${isNotDevEnv}`,
-      `--csvFolder=${pathToUserData}/csv`,
+      `--csvFolder=${pathToCsvFolder}/csv`,
       `--tempFolder=${pathToUserData}/temp`,
       `--logsFolder=${pathToUserData}/logs`,
       `--dbFolder=${pathToUserData}`,

--- a/server.js
+++ b/server.js
@@ -4,7 +4,6 @@ const { fork } = require('child_process')
 const path = require('path')
 const { writeFileSync } = require('fs')
 const EventEmitter = require('events')
-const electron = require('electron')
 
 const root = path.join(__dirname, 'bfx-reports-framework')
 const expressRoot = path.join(__dirname, 'bfx-report-ui/bfx-report-express')
@@ -45,8 +44,7 @@ let isMigrationsError = false
 
 ;(async () => {
   try {
-    const app = electron.app || electron.remote.app
-    const pathToUserData = app.getPath('userData')
+    const pathToUserData = process.env.PATH_TO_USER_DATA
     const defaultPorts = getDefaultPorts()
     const ports = await getFreePort(defaultPorts)
     const grape = `http://127.0.0.1:${ports.grape2ApiPort}`

--- a/src/create-menu.js
+++ b/src/create-menu.js
@@ -10,9 +10,11 @@ const exportDB = require('./export-db')
 const importDB = require('./import-db')
 
 const dbFileName = 'db-sqlite_sync_m0.db'
-const dbPath = path.join(__dirname, '../bfx-reports-framework/db', dbFileName)
 
 module.exports = () => {
+  const pathToUserData = app.getPath('userData')
+  const dbPath = path.join(pathToUserData, dbFileName)
+
   const menuTemplate = [
     {
       label: 'Application',

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -9,7 +9,6 @@ const {
   getDefaultPorts
 } = require('./ports')
 const {
-  checkAndChangeAccess,
   serializeError,
   deserializeError
 } = require('./utils')
@@ -19,7 +18,6 @@ module.exports = {
   killGrapes,
   getFreePort,
   getDefaultPorts,
-  checkAndChangeAccess,
   serializeError,
   deserializeError
 }

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -9,7 +9,8 @@ const {
   getDefaultPorts
 } = require('./ports')
 const {
-  checkAndChangeAccess
+  checkAndChangeAccess,
+  serializeError
 } = require('./utils')
 
 module.exports = {
@@ -17,5 +18,6 @@ module.exports = {
   killGrapes,
   getFreePort,
   getDefaultPorts,
-  checkAndChangeAccess
+  checkAndChangeAccess,
+  serializeError
 }

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -10,7 +10,8 @@ const {
 } = require('./ports')
 const {
   checkAndChangeAccess,
-  serializeError
+  serializeError,
+  deserializeError
 } = require('./utils')
 
 module.exports = {
@@ -19,5 +20,6 @@ module.exports = {
   getFreePort,
   getDefaultPorts,
   checkAndChangeAccess,
-  serializeError
+  serializeError,
+  deserializeError
 }

--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -10,6 +10,29 @@ const checkAndChangeAccess = (path) => {
   }
 }
 
+const serializeError = (err) => {
+  if (!(err instanceof Error)) {
+    return err
+  }
+
+  return {
+    toJSON () {
+      return Object.keys(err).reduce((obj, key) => {
+        console.log('[key]:', key)
+        obj[key] = err[key]
+
+        return obj
+      }, {
+        name: err.name,
+        message: err.message,
+        stack: err.stack,
+        isError: true
+      })
+    }
+  }
+}
+
 module.exports = {
-  checkAndChangeAccess
+  checkAndChangeAccess,
+  serializeError
 }

--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -1,15 +1,5 @@
 'use strict'
 
-const fs = require('fs')
-
-const checkAndChangeAccess = (path) => {
-  try {
-    fs.accessSync(path, fs.constants.R_OK | fs.constants.W_OK)
-  } catch (err) {
-    fs.chmodSync(path, '766')
-  }
-}
-
 const serializeError = (err) => {
   if (!(err instanceof Error)) {
     return err
@@ -49,7 +39,6 @@ const deserializeError = (err) => {
 }
 
 module.exports = {
-  checkAndChangeAccess,
   serializeError,
   deserializeError
 }

--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -32,7 +32,24 @@ const serializeError = (err) => {
   }
 }
 
+const deserializeError = (err) => {
+  if (
+    !err ||
+    typeof err !== 'object' ||
+    !err.isError
+  ) {
+    return err
+  }
+
+  return Object.keys(err).reduce((error, key) => {
+    error[key] = err[key]
+
+    return error
+  }, new Error())
+}
+
 module.exports = {
   checkAndChangeAccess,
-  serializeError
+  serializeError,
+  deserializeError
 }

--- a/src/initialize-app.js
+++ b/src/initialize-app.js
@@ -22,6 +22,9 @@ const {
   IpcMessageError,
   AppInitializationError
 } = require('./errors')
+const {
+  deserializeError
+} = require('./helpers')
 
 const pathToLayouts = path.join(__dirname, 'layouts')
 const pathToLayoutAppInitErr = path.join(pathToLayouts, 'app-init-error.html')
@@ -30,7 +33,17 @@ const pathToLayoutExprPortReq = path.join(pathToLayouts, 'express-port-required.
 const _ipcMessToPromise = (ipc) => {
   return new Promise((resolve, reject) => {
     try {
-      ipc.once('message', resolve)
+      ipc.once('message', (mess) => {
+        if (
+          mess ||
+          typeof mess === 'object' ||
+          typeof mess.err === 'string'
+        ) {
+          mess.err = deserializeError(mess.err)
+        }
+
+        resolve(mess)
+      })
     } catch (err) {
       reject(err)
     }

--- a/src/run-server.js
+++ b/src/run-server.js
@@ -2,15 +2,19 @@
 
 const { fork } = require('child_process')
 const path = require('path')
+const electron = require('electron')
 
 const ipcs = require('./ipcs')
 
 const serverPath = path.join(__dirname, '../server.js')
 
 module.exports = () => {
+  const app = electron.app || electron.remote.app
+  const pathToUserData = app.getPath('userData')
   const env = {
     ...process.env,
-    ELECTRON_VERSION: process.versions.electron
+    ELECTRON_VERSION: process.versions.electron,
+    PATH_TO_USER_DATA: pathToUserData
   }
   const ipc = fork(serverPath, [], {
     env,


### PR DESCRIPTION
This PR fixes launching on mac by double click. Basic changes:
  - moves writing files as temporary csv files, logs, dbs of lokue queues, sqlite db to the `app.getPath('userData')` directory https://electronjs.org/docs/all#appgetpathname
  - moves writing csv reports in `~/Library/Application Support/bfx-report-electron/csv` (`app.getPath('userData')`) directory for Mac release
  - adds an ability to set grape address without overwriting config file

**Depends** on this PR [bfx-reports-framework#71](https://github.com/bitfinexcom/bfx-reports-framework/pull/71)