### PR TITLE
Isolate electron-builder env into docker containers

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+**/node_modules
+.env
+.env.example
+docker-compose.yml
+Dockerfile.linux-builder
+Dockerfile.win-builder
+Dockerfile.mac-builder
+dist

--- a/Dockerfile.linux-builder
+++ b/Dockerfile.linux-builder
@@ -1,0 +1,6 @@
+FROM electronuserland/builder:10
+
+COPY . .
+
+ENTRYPOINT ["./init.sh"]
+CMD ["-p", "linux"]

--- a/Dockerfile.mac-builder
+++ b/Dockerfile.mac-builder
@@ -1,0 +1,6 @@
+FROM electronuserland/builder:10
+
+COPY . .
+
+ENTRYPOINT ["./init.sh"]
+CMD ["-p", "mac"]

--- a/Dockerfile.win-builder
+++ b/Dockerfile.win-builder
@@ -1,0 +1,6 @@
+FROM electronuserland/builder:wine-05.18
+
+COPY . .
+
+ENTRYPOINT ["./init.sh"]
+CMD ["-p", "win"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,41 @@
+version: '3.7'
+
+services:
+  linux-builder:
+    container_name: linux-builder
+    build:
+      context: .
+      dockerfile: Dockerfile.linux-builder
+    environment:
+      ELECTRON_CACHE: /root/.cache/electron
+      ELECTRON_BUILDER_CACHE: /root/.cache/electron-builder
+    volumes:
+      - ./dist:/project/dist
+      - ~/.cache/electron:/root/.cache/electron
+      - ~/.cache/electron-builder:/root/.cache/electron-builder
+
+  win-builder:
+    container_name: win-builder
+    build:
+      context: .
+      dockerfile: Dockerfile.win-builder
+    environment:
+      ELECTRON_CACHE: /root/.cache/electron
+      ELECTRON_BUILDER_CACHE: /root/.cache/electron-builder
+    volumes:
+      - ./dist:/project/dist
+      - ~/.cache/electron:/root/.cache/electron
+      - ~/.cache/electron-builder:/root/.cache/electron-builder
+
+  mac-builder:
+    container_name: mac-builder
+    build:
+      context: .
+      dockerfile: Dockerfile.mac-builder
+    environment:
+      ELECTRON_CACHE: /root/.cache/electron
+      ELECTRON_BUILDER_CACHE: /root/.cache/electron-builder
+    volumes:
+      - ./dist:/project/dist
+      - ~/.cache/electron:/root/.cache/electron
+      - ~/.cache/electron-builder:/root/.cache/electron-builder

--- a/init.sh
+++ b/init.sh
@@ -14,6 +14,7 @@ ROOT=$PWD
 programname=$0
 isDevEnv=0
 isNotSkippedReiDeps=1
+targetPlatform=0
 
 function usage {
   echo "Usage: $programname [-d] | [-h]"
@@ -27,6 +28,8 @@ while [ "$1" != "" ]; do
     -d | --dev )    isDevEnv=1
                     ;;
     -s | --skip-rei-deps )    isNotSkippedReiDeps=0
+                    ;;
+    -p | --target-platform )  targetPlatform=$2; shift
                     ;;
     -h | --help )   usage
                     exit
@@ -93,5 +96,12 @@ fi
 cd $ROOT
 
 if [ $isNotSkippedReiDeps != 0 ]; then
-  bash ./reinstall-deps.sh
+  if [ $targetPlatform != 0 ]
+  then
+    bash ./reinstall-deps.sh $targetPlatform
+    ./node_modules/.bin/electron-builder build --$targetPlatform 2>/dev/null
+    exit 0
+  else
+    bash ./reinstall-deps.sh
+  fi
 fi

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "electron": "2.0.18",
-    "electron-builder": "21.2.0",
+    "electron-builder": "22.4.1",
     "electron-rebuild": "^1.8.2",
     "node-gyp": "6.0.1",
     "node-pre-gyp": "^0.11.0",

--- a/reinstall-deps.sh
+++ b/reinstall-deps.sh
@@ -2,7 +2,38 @@
 
 set -x
 
-ELECTRON_VER="2.0.18"
+function getModuleVersion {
+  local prevFolder=$PWD
+  local dep=""
+  local version=""
+
+  if [ $# -ge 1 ]
+  then
+    dep=$1
+  else
+    return
+  fi
+  if [ $# -ge 2 ]
+  then
+    cd $2
+  fi
+
+  version=$(cat package.json \
+    | grep \"$dep\" \
+    | head -1 \
+    | awk -F: '{ print $2 }' \
+    | sed 's/[",]//g' \
+    | tr -d '[[:space:]]')
+
+  if [ $# -ge 1 ]
+  then
+    cd $prevFolder
+  fi
+
+  echo $version
+}
+
+ELECTRON_VER=$(getModuleVersion "electron" $PWD)
 ARCH="x64"
 ROOT=$PWD
 DIST_URL=https://atom.io/download/electron
@@ -22,42 +53,11 @@ targetPlatform=$machine
 
 if [ $# -ge 1 ]
 then
-  targetPlatform=$1
+  targetPlatform=$1 | sed 's/win$/win32/' | sed 's/mac/darwin/'
 fi
 
 backendFolder="$ROOT/bfx-reports-framework"
 expressFolder="$ROOT/bfx-report-ui/bfx-report-express"
-
-function getModuleVersion {
-  local prevFolder=$PWD
-  local dep=""
-  local version=""
-
-  if [ $# -ge 1 ]
-  then
-    dep=$1
-  else
-    return
-  fi
-  if [ $# -ge 2 ]
-  then
-    cd $2
-  fi
-
-  version=$(cat package.json \
-    | grep $dep \
-    | head -1 \
-    | awk -F: '{ print $2 }' \
-    | sed 's/[",]//g' \
-    | tr -d '[[:space:]]')
-
-  if [ $# -ge 1 ]
-  then
-    cd $prevFolder
-  fi
-
-  echo $version
-}
 
 function npmInstallDep {
   local prevFolder=$PWD


### PR DESCRIPTION
This PR isolates `electron-builder` environment into docker containers to be more independent from the host machine