### PR TITLE
Turn off apple app sandbox for standard darwin build

### DIFF
--- a/build/entitlements.mac.plist
+++ b/build/entitlements.mac.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
   <dict>
-    <key>com.apple.security.app-sandbox</key>
-    <true/>
     <key>com.apple.security.inherit</key>
     <true/>
     <key>com.apple.security.network.client</key>

--- a/build/entitlements.mas.inherit.plist
+++ b/build/entitlements.mas.inherit.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
   <dict>
-    <key>com.apple.security.app-sandbox</key>
-    <true/>
     <key>com.apple.security.inherit</key>
     <true/>
     <key>com.apple.security.network.client</key>


### PR DESCRIPTION
This PR turns off apple app sandbox for standard darwin build